### PR TITLE
null check for map offset added

### DIFF
--- a/layers/VerticalScrollMap.js
+++ b/layers/VerticalScrollMap.js
@@ -68,7 +68,7 @@ adv_map.layers.VerticalScrollMap = cc.ScrollView.extend({
 
     var start_pos, end_pos;
 
-    if (this.map_built) {
+    if (this.map_built && this.map_offset) {
       start_pos = this.map_offset.y;
       end_pos = this.getContentOffset().y;
 


### PR DESCRIPTION
After removing focusNodeByMs from module [since we should handle that from the game] for bonus/gifting icon, fresh user who goes to tutorial first and then map gets a js error since the offset is not set yet.